### PR TITLE
480 implemend the missing keys

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,8 @@ RUN git clone https://github.com/jensvogt/awsmock.git && \
 # Cleanup
 RUN rm -rf /usr/src
 
-FROM alpine:latest
+# Stick to alpine 3.19 as 3.20 has not support for aws-cli (missing python3.12 compat)
+FROM alpine:3.19
 
 RUN apk update && apk add aws-cli
 

--- a/src/core/include/awsmock/core/Version.h
+++ b/src/core/include/awsmock/core/Version.h
@@ -6,6 +6,6 @@
 #define AWSMOCK_CORE_VERSION_H_IN_H
 
 #define PROJECT_NAME "awsmock"
-#define PROJECT_VERSION "0.11.64"
+#define PROJECT_VERSION "0.11.65"
 
 #endif //AWSMOCK_CORE_VERSION_H_IN_H


### PR DESCRIPTION
Go back to alpine 3.19, as 3.20 has no aws-cli (missing python 3.12 compat)