### PR TITLE
2084-application-collection-unique-index

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,7 +181,7 @@ set(DB_SOURCES db/src/entity/sqs/MessageAttribute.cpp db/src/entity/sqs/Message.
         db/src/utils/ConnectionPool.cpp db/src/utils/SqsUtils.cpp db/src/entity/dynamodb/Tag.cpp
         db/src/repository/apigateway/ApiGatewayMongoRepository.cpp db/src/repository/apigateway/ApiGatewayMemoryRepository.cpp
         db/src/entity/apigateway/ApiKey.cpp db/src/entity/apigateway/RestApi.cpp db/src/entity/apigateway/Resource.cpp
-        db/src/entity/apigateway/Authorizer.cpp db/src/entity/apigateway/ResourceMethod.cpp db/src/entity/monitoring/Counter.cpp db/src/entity/dynamodb/KeySchema.cpp
+        db/src/entity/apigateway/Authorizer.cpp db/src/entity/apigateway/ResourceMethod.cpp db/src/entity/apigateway/UsagePlan.cpp db/src/entity/monitoring/Counter.cpp db/src/entity/dynamodb/KeySchema.cpp
         db/src/repository/monitoring/MonitoringMongoRepository.cpp db/src/repository/monitoring/MonitoringMemoryRepository.cpp
         db/src/utils/TestUtils.cpp db/src/entity/dynamodb/AttributeDefinition.cpp
         db/src/repository/RepositoryFactory.cpp

--- a/db/include/awsmock/entity/apigateway/UsagePlan.h
+++ b/db/include/awsmock/entity/apigateway/UsagePlan.h
@@ -1,5 +1,5 @@
 //
-// Created by vogje01 on 11/25/23.
+// Created by vogje01 on 07/08/2026
 //
 
 #pragma once
@@ -11,11 +11,41 @@
 namespace Awsmock::Database::Entity::ApiGateway {
 
     /**
-     * @brief API gateway key entity
+     * @brief API gateway usage plan quota settings
+     */
+    struct UsagePlanQuota {
+
+        long limit{};
+
+        long offset{};
+
+        std::string period;
+
+        [[nodiscard]] view_or_value<view, value> ToDocument() const;
+
+        void FromDocument(const std::optional<view> &doc);
+    };
+
+    /**
+     * @brief API gateway usage plan throttle settings
+     */
+    struct UsagePlanThrottle {
+
+        long burstLimit{};
+
+        double rateLimit{};
+
+        [[nodiscard]] view_or_value<view, value> ToDocument() const;
+
+        void FromDocument(const std::optional<view> &doc);
+    };
+
+    /**
+     * @brief API gateway usage plan entity
      *
      * @author jens.vogt\@opitz-consulting.com
      */
-    struct ApiKey final : Common::BaseEntity<ApiKey> {
+    struct UsagePlan final : Common::BaseEntity<UsagePlan> {
 
         /**
          * MongoDB OID
@@ -23,24 +53,19 @@ namespace Awsmock::Database::Entity::ApiGateway {
         std::string oid;
 
         /**
-         * API ID
-         */
-        std::string id;
-
-        /**
-         * Aws region
+         * AWS region
          */
         std::string region;
 
         /**
-         * Application name
+         * Usage plan ID
          */
-        std::string name;
+        std::string id;
 
         /**
-         * Customer ID
+         * Usage plan name
          */
-        std::string customerId;
+        std::string name;
 
         /**
          * Description
@@ -48,29 +73,19 @@ namespace Awsmock::Database::Entity::ApiGateway {
         std::string description;
 
         /**
-         * Enabled
+         * Quota settings
          */
-        bool enabled{};
+        UsagePlanQuota quota;
 
         /**
-         * Generate distinct
+         * Throttle settings
          */
-        bool generateDistinct{};
+        UsagePlanThrottle throttle;
 
         /**
          * Tags
          */
         std::map<std::string, std::string> tags;
-
-        /**
-         * Usage plan ID this key is associated with
-         */
-        std::string usagePlanId;
-
-        /**
-         * Value
-         */
-        std::string keyValue;
 
         /**
          * Creation date
@@ -85,14 +100,14 @@ namespace Awsmock::Database::Entity::ApiGateway {
         /**
          * @brief Converts the entity to a MongoDB document
          *
-         * @return entity as MongoDB document.
+         * @return entity as MongoDB document
          */
         [[nodiscard]] view_or_value<view, value> ToDocument() const override;
 
         /**
          * @brief Converts the MongoDB document to an entity
          *
-         * @param mResult query result.
+         * @param mResult query result
          */
         void FromDocument(const std::optional<view> &mResult);
     };

--- a/db/include/awsmock/repository/apigateway/ApiGatewayMemoryRepository.h
+++ b/db/include/awsmock/repository/apigateway/ApiGatewayMemoryRepository.h
@@ -14,6 +14,8 @@
 // AwsMock includes
 #include <awsmock/core/Linq.h>
 #include <awsmock/core/NumberUtils.h>
+#include <awsmock/core/StringUtils.h>
+#include <awsmock/core/exception/DatabaseException.h>
 #include <awsmock/entity/apigateway/ApiKey.h>
 #include <awsmock/entity/apigateway/RestApi.h>
 #include <awsmock/repository/apigateway/IApiGatewayRepository.h>
@@ -275,6 +277,23 @@ namespace Awsmock::Database {
         [[nodiscard]]
         std::vector<Entity::ApiGateway::RestApi> listRestApis() const override;
 
+        [[nodiscard]]
+        bool usagePlanExists(const std::string &id) const override;
+
+        [[nodiscard]]
+        Entity::ApiGateway::UsagePlan createUsagePlan(Entity::ApiGateway::UsagePlan &usagePlan) const override;
+
+        [[nodiscard]]
+        Entity::ApiGateway::UsagePlan getUsagePlanById(const std::string &id) const override;
+
+        [[nodiscard]]
+        std::vector<Entity::ApiGateway::UsagePlan> listUsagePlans() const override;
+
+        void deleteUsagePlan(const std::string &id) const override;
+
+        [[nodiscard]]
+        long deleteAllUsagePlans() const override;
+
     private:
         /**
          * @brief Channeled logger
@@ -300,6 +319,10 @@ namespace Awsmock::Database {
          * REST API mutex
          */
         static boost::mutex _restApiMutex;
+
+        mutable std::unordered_map<std::string, Entity::ApiGateway::UsagePlan> _usagePlans{};
+
+        static boost::mutex _usagePlanMutex;
     };
 
 } // namespace Awsmock::Database

--- a/db/include/awsmock/repository/apigateway/ApiGatewayMongoRepository.h
+++ b/db/include/awsmock/repository/apigateway/ApiGatewayMongoRepository.h
@@ -271,6 +271,23 @@ namespace Awsmock::Database {
         [[nodiscard]]
         long deleteRestApi(const std::string &restApiId) const override;
 
+        [[nodiscard]]
+        bool usagePlanExists(const std::string &id) const override;
+
+        [[nodiscard]]
+        Entity::ApiGateway::UsagePlan createUsagePlan(Entity::ApiGateway::UsagePlan &usagePlan) const override;
+
+        [[nodiscard]]
+        Entity::ApiGateway::UsagePlan getUsagePlanById(const std::string &id) const override;
+
+        [[nodiscard]]
+        std::vector<Entity::ApiGateway::UsagePlan> listUsagePlans() const override;
+
+        void deleteUsagePlan(const std::string &id) const override;
+
+        [[nodiscard]]
+        long deleteAllUsagePlans() const override;
+
     private:
         /**
          * @brief Channeled logger
@@ -291,6 +308,8 @@ namespace Awsmock::Database {
          * @brief User pool collection name
          */
         static constexpr auto _restApiCollectionName = "apigateway_rest";
+
+        static constexpr auto _usagePlanCollectionName = "apigateway_usage_plan";
     };
 
 } // namespace Awsmock::Database

--- a/db/include/awsmock/repository/apigateway/IApiGatewayRepository.h
+++ b/db/include/awsmock/repository/apigateway/IApiGatewayRepository.h
@@ -12,6 +12,7 @@
 // Awsmock includes
 #include <awsmock/entity/apigateway/ApiKey.h>
 #include <awsmock/entity/apigateway/RestApi.h>
+#include <awsmock/entity/apigateway/UsagePlan.h>
 #include <awsmock/utils/SortColumn.h>
 
 namespace Awsmock::Database {
@@ -273,6 +274,23 @@ namespace Awsmock::Database {
          */
         [[nodiscard]]
         virtual long deleteRestApi(const std::string &restApiId) const = 0;
+
+        [[nodiscard]]
+        virtual bool usagePlanExists(const std::string &id) const = 0;
+
+        [[nodiscard]]
+        virtual Entity::ApiGateway::UsagePlan createUsagePlan(Entity::ApiGateway::UsagePlan &usagePlan) const = 0;
+
+        [[nodiscard]]
+        virtual Entity::ApiGateway::UsagePlan getUsagePlanById(const std::string &id) const = 0;
+
+        [[nodiscard]]
+        virtual std::vector<Entity::ApiGateway::UsagePlan> listUsagePlans() const = 0;
+
+        virtual void deleteUsagePlan(const std::string &id) const = 0;
+
+        [[nodiscard]]
+        virtual long deleteAllUsagePlans() const = 0;
     };
 
 }// namespace Awsmock::Database

--- a/db/src/entity/apigateway/ApiKey.cpp
+++ b/db/src/entity/apigateway/ApiKey.cpp
@@ -16,6 +16,7 @@ namespace Awsmock::Database::Entity::ApiGateway {
         keyDocument.append(kvp("description", description));
         keyDocument.append(kvp("enabled", enabled));
         keyDocument.append(kvp("generateDistinct", generateDistinct));
+        keyDocument.append(kvp("usagePlanId", usagePlanId));
         keyDocument.append(kvp("value", keyValue));
         keyDocument.append(kvp("created", bsoncxx::types::b_date(created)));
         keyDocument.append(kvp("modified", bsoncxx::types::b_date(modified)));
@@ -41,6 +42,7 @@ namespace Awsmock::Database::Entity::ApiGateway {
         description = Core::Bson::BsonUtils::GetStringValue(mResult, "description");
         enabled = Core::Bson::BsonUtils::GetBoolValue(mResult, "enabled");
         generateDistinct = Core::Bson::BsonUtils::GetBoolValue(mResult, "generateDistinct");
+        usagePlanId = Core::Bson::BsonUtils::GetStringValue(mResult, "usagePlanId");
         keyValue = Core::Bson::BsonUtils::GetStringValue(mResult, "value");
         created = Core::Bson::BsonUtils::GetDateValue(mResult, "created");
         modified = Core::Bson::BsonUtils::GetDateValue(mResult, "modified");

--- a/db/src/entity/apigateway/UsagePlan.cpp
+++ b/db/src/entity/apigateway/UsagePlan.cpp
@@ -1,0 +1,89 @@
+//
+// Created by vogje01 on 07/08/2026
+//
+
+#include <awsmock/entity/apigateway/UsagePlan.h>
+
+namespace Awsmock::Database::Entity::ApiGateway {
+
+    view_or_value<view, value> UsagePlanQuota::ToDocument() const {
+        document doc;
+        doc.append(kvp("limit", bsoncxx::types::b_int64(limit)));
+        doc.append(kvp("offset", bsoncxx::types::b_int64(offset)));
+        doc.append(kvp("period", period));
+        return doc.extract();
+    }
+
+    void UsagePlanQuota::FromDocument(const std::optional<view> &doc) {
+        limit = Core::Bson::BsonUtils::GetLongValue(doc, "limit");
+        offset = Core::Bson::BsonUtils::GetLongValue(doc, "offset");
+        period = Core::Bson::BsonUtils::GetStringValue(doc, "period");
+    }
+
+    view_or_value<view, value> UsagePlanThrottle::ToDocument() const {
+        document doc;
+        doc.append(kvp("burstLimit", bsoncxx::types::b_int64(burstLimit)));
+        doc.append(kvp("rateLimit", rateLimit));
+        return doc.extract();
+    }
+
+    void UsagePlanThrottle::FromDocument(const std::optional<view> &doc) {
+        burstLimit = Core::Bson::BsonUtils::GetLongValue(doc, "burstLimit");
+        rateLimit = Core::Bson::BsonUtils::GetDoubleValue(doc, "rateLimit");
+    }
+
+    view_or_value<view, value> UsagePlan::ToDocument() const {
+
+        document planDocument;
+        planDocument.append(kvp("region", region));
+        planDocument.append(kvp("id", id));
+        planDocument.append(kvp("name", name));
+        planDocument.append(kvp("description", description));
+        planDocument.append(kvp("quota", quota.ToDocument()));
+        planDocument.append(kvp("throttle", throttle.ToDocument()));
+        planDocument.append(kvp("created", bsoncxx::types::b_date(created)));
+        planDocument.append(kvp("modified", bsoncxx::types::b_date(modified)));
+
+        if (!tags.empty()) {
+            document tagsDoc;
+            for (const auto &[k, v]: tags) {
+                tagsDoc.append(kvp(k, v));
+            }
+            planDocument.append(kvp("tags", tagsDoc));
+        }
+        return planDocument.extract();
+    }
+
+    void UsagePlan::FromDocument(const std::optional<view> &mResult) {
+
+        oid = Core::Bson::BsonUtils::GetOidValue(mResult, "_id");
+        region = Core::Bson::BsonUtils::GetStringValue(mResult, "region");
+        id = Core::Bson::BsonUtils::GetStringValue(mResult, "id");
+        name = Core::Bson::BsonUtils::GetStringValue(mResult, "name");
+        description = Core::Bson::BsonUtils::GetStringValue(mResult, "description");
+        created = Core::Bson::BsonUtils::GetDateValue(mResult, "created");
+        modified = Core::Bson::BsonUtils::GetDateValue(mResult, "modified");
+
+        if (mResult.value().find("quota") != mResult.value().end()) {
+            const view quotaView = mResult.value()["quota"].get_document().value;
+            const std::optional<view> quotaOpt = quotaView;
+            quota.FromDocument(quotaOpt);
+        }
+
+        if (mResult.value().find("throttle") != mResult.value().end()) {
+            const view throttleView = mResult.value()["throttle"].get_document().value;
+            const std::optional<view> throttleOpt = throttleView;
+            throttle.FromDocument(throttleOpt);
+        }
+
+        if (mResult.value().find("tags") != mResult.value().end()) {
+            tags.clear();
+            for (const view tagsObject = mResult.value()["tags"].get_document().value; const auto &t: tagsObject) {
+                const std::string key = bsoncxx::string::to_string(t.key());
+                const std::string val = bsoncxx::string::to_string(tagsObject[key].get_string().value);
+                tags[key] = val;
+            }
+        }
+    }
+
+}// namespace Awsmock::Database::Entity::ApiGateway

--- a/db/src/repository/apigateway/ApiGatewayMemoryRepository.cpp
+++ b/db/src/repository/apigateway/ApiGatewayMemoryRepository.cpp
@@ -10,6 +10,7 @@ namespace Awsmock::Database {
 
     boost::mutex ApiGatewayMemoryRepository::_apiKeyMutex;
     boost::mutex ApiGatewayMemoryRepository::_restApiMutex;
+    boost::mutex ApiGatewayMemoryRepository::_usagePlanMutex;
 
     logger_t _logger{boost::log::keywords::channel = "ApiGateway"};
 
@@ -303,6 +304,53 @@ namespace Awsmock::Database {
             return value.id == restApiId;
         });
         log_debug << "REST API deleted, count: " << count;
+        return count;
+    }
+
+    // ========================================================================================================================
+    // Usage plan
+    // ========================================================================================================================
+    bool ApiGatewayMemoryRepository::usagePlanExists(const std::string &id) const {
+        return std::ranges::find_if(_usagePlans,
+                                    [id](const std::pair<std::string, Entity::ApiGateway::UsagePlan> &p) {
+                                        return p.second.id == id;
+                                    }) != _usagePlans.end();
+    }
+
+    Entity::ApiGateway::UsagePlan ApiGatewayMemoryRepository::createUsagePlan(Entity::ApiGateway::UsagePlan &usagePlan) const {
+        boost::mutex::scoped_lock lock(_usagePlanMutex);
+        usagePlan.oid = Core::StringUtils::CreateRandomUuid();
+        _usagePlans[usagePlan.oid] = usagePlan;
+        return _usagePlans[usagePlan.oid];
+    }
+
+    Entity::ApiGateway::UsagePlan ApiGatewayMemoryRepository::getUsagePlanById(const std::string &id) const {
+        boost::mutex::scoped_lock lock(_usagePlanMutex);
+        const auto it = std::ranges::find_if(_usagePlans,
+                                              [id](const std::pair<std::string, Entity::ApiGateway::UsagePlan> &p) {
+                                                  return p.second.id == id;
+                                              });
+        if (it == _usagePlans.end()) throw Core::DatabaseException("Usage plan not found, id: " + id);
+        return it->second;
+    }
+
+    std::vector<Entity::ApiGateway::UsagePlan> ApiGatewayMemoryRepository::listUsagePlans() const {
+        boost::mutex::scoped_lock lock(_usagePlanMutex);
+        std::vector<Entity::ApiGateway::UsagePlan> result;
+        result.reserve(_usagePlans.size());
+        for (const auto &[k, v]: _usagePlans) result.push_back(v);
+        return result;
+    }
+
+    void ApiGatewayMemoryRepository::deleteUsagePlan(const std::string &id) const {
+        boost::mutex::scoped_lock lock(_usagePlanMutex);
+        std::erase_if(_usagePlans, [id](const auto &item) { return item.second.id == id; });
+    }
+
+    long ApiGatewayMemoryRepository::deleteAllUsagePlans() const {
+        boost::mutex::scoped_lock lock(_usagePlanMutex);
+        const long count = static_cast<long>(_usagePlans.size());
+        _usagePlans.clear();
         return count;
     }
 

--- a/db/src/repository/apigateway/ApiGatewayMongoRepository.cpp
+++ b/db/src/repository/apigateway/ApiGatewayMongoRepository.cpp
@@ -558,4 +558,87 @@ namespace Awsmock::Database {
         }
     }
 
+    // ========================================================================================================================
+    // Usage plan
+    // ========================================================================================================================
+    bool ApiGatewayMongoRepository::usagePlanExists(const std::string &id) const {
+        try {
+            const auto client = ConnectionPool::instance().GetConnection();
+            mongocxx::collection col = client->database(_databaseName)[_usagePlanCollectionName];
+            return col.count_documents(make_document(kvp("id", id))) > 0;
+        } catch (const mongocxx::exception &exc) {
+            log_error << "Database exception " << exc.what();
+            throw Core::DatabaseException("Database exception " + std::string(exc.what()));
+        }
+    }
+
+    Entity::ApiGateway::UsagePlan ApiGatewayMongoRepository::createUsagePlan(Entity::ApiGateway::UsagePlan &usagePlan) const {
+        usagePlan.created = system_clock::now();
+        const auto client = ConnectionPool::instance().GetConnection();
+        mongocxx::collection col = client->database(_databaseName)[_usagePlanCollectionName];
+        try {
+            const auto result = col.insert_one(usagePlan.ToDocument());
+            usagePlan.oid = result->inserted_id().get_oid().value.to_string();
+            return usagePlan;
+        } catch (const mongocxx::exception &exc) {
+            log_error << "Database exception " << exc.what();
+            throw Core::DatabaseException("Database exception " + std::string(exc.what()));
+        }
+    }
+
+    Entity::ApiGateway::UsagePlan ApiGatewayMongoRepository::getUsagePlanById(const std::string &id) const {
+        const auto client = ConnectionPool::instance().GetConnection();
+        mongocxx::collection col = client->database(_databaseName)[_usagePlanCollectionName];
+        try {
+            const auto result = col.find_one(make_document(kvp("id", id)));
+            if (!result) throw Core::DatabaseException("Usage plan not found, id: " + id);
+            Entity::ApiGateway::UsagePlan plan;
+            plan.FromDocument(result->view());
+            return plan;
+        } catch (const mongocxx::exception &exc) {
+            log_error << "Database exception " << exc.what();
+            throw Core::DatabaseException("Database exception " + std::string(exc.what()));
+        }
+    }
+
+    std::vector<Entity::ApiGateway::UsagePlan> ApiGatewayMongoRepository::listUsagePlans() const {
+        const auto client = ConnectionPool::instance().GetConnection();
+        mongocxx::collection col = client->database(_databaseName)[_usagePlanCollectionName];
+        try {
+            std::vector<Entity::ApiGateway::UsagePlan> result;
+            for (auto cursor = col.find({}); const auto &doc: cursor) {
+                Entity::ApiGateway::UsagePlan plan;
+                plan.FromDocument(doc);
+                result.push_back(plan);
+            }
+            return result;
+        } catch (const mongocxx::exception &exc) {
+            log_error << "Database exception " << exc.what();
+            throw Core::DatabaseException("Database exception " + std::string(exc.what()));
+        }
+    }
+
+    void ApiGatewayMongoRepository::deleteUsagePlan(const std::string &id) const {
+        const auto client = ConnectionPool::instance().GetConnection();
+        mongocxx::collection col = client->database(_databaseName)[_usagePlanCollectionName];
+        try {
+            col.delete_one(make_document(kvp("id", id)));
+        } catch (const mongocxx::exception &exc) {
+            log_error << "Database exception " << exc.what();
+            throw Core::DatabaseException("Database exception " + std::string(exc.what()));
+        }
+    }
+
+    long ApiGatewayMongoRepository::deleteAllUsagePlans() const {
+        const auto client = ConnectionPool::instance().GetConnection();
+        mongocxx::collection col = client->database(_databaseName)[_usagePlanCollectionName];
+        try {
+            const auto result = col.delete_many({});
+            return result->deleted_count();
+        } catch (const mongocxx::exception &exc) {
+            log_error << "Database exception " << exc.what();
+            throw Core::DatabaseException("Database exception " + std::string(exc.what()));
+        }
+    }
+
 }// namespace Awsmock::Database

--- a/dto/include/awsmock/dto/apigateway/CreateUsagePlanKeyRequest.h
+++ b/dto/include/awsmock/dto/apigateway/CreateUsagePlanKeyRequest.h
@@ -1,0 +1,58 @@
+//
+// Created by vogje01 on 07/08/2026
+//
+
+#pragma once
+
+// C++ standard includes
+#include <string>
+
+// AwsMock includes
+#include <awsmock/dto/common/BaseCounter.h>
+
+namespace Awsmock::Dto::ApiGateway {
+
+    /**
+     * @brief Create usage plan key request
+     *
+     * @author jens.vogt\@opitz-consulting.com
+     */
+    struct CreateUsagePlanKeyRequest final : Common::BaseCounter<CreateUsagePlanKeyRequest> {
+
+        /**
+         * Usage plan ID (from path)
+         */
+        std::string usagePlanId;
+
+        /**
+         * API key ID to associate
+         */
+        std::string keyId;
+
+        /**
+         * Key type (always "API_KEY")
+         */
+        std::string keyType{"API_KEY"};
+
+      private:
+
+        friend CreateUsagePlanKeyRequest tag_invoke(boost::json::value_to_tag<CreateUsagePlanKeyRequest>, boost::json::value const &v) {
+            CreateUsagePlanKeyRequest r;
+            r.keyId = Core::Json::GetStringValue(v, "keyId");
+            r.keyType = Core::Json::GetStringValue(v, "keyType");
+            return r;
+        }
+
+        friend void tag_invoke(boost::json::value_from_tag, boost::json::value &jv, CreateUsagePlanKeyRequest const &obj) {
+            jv = {
+                    {"Region", obj.region},
+                    {"User", obj.user},
+                    {"RequestId", obj.requestId},
+                    {"usagePlanId", obj.usagePlanId},
+                    {"keyId", obj.keyId},
+                    {"keyType", obj.keyType},
+            };
+        }
+    };
+
+}// namespace Awsmock::Dto::ApiGateway

--- a/dto/include/awsmock/dto/apigateway/CreateUsagePlanKeyResponse.h
+++ b/dto/include/awsmock/dto/apigateway/CreateUsagePlanKeyResponse.h
@@ -1,0 +1,66 @@
+//
+// Created by vogje01 on 07/08/2026
+//
+
+#pragma once
+
+// C++ standard includes
+#include <string>
+
+// AwsMock includes
+#include <awsmock/dto/common/BaseCounter.h>
+
+namespace Awsmock::Dto::ApiGateway {
+
+    /**
+     * @brief Create usage plan key response
+     *
+     * @author jens.vogt\@opitz-consulting.com
+     */
+    struct CreateUsagePlanKeyResponse final : Common::BaseCounter<CreateUsagePlanKeyResponse> {
+
+        /**
+         * API key ID
+         */
+        std::string id;
+
+        /**
+         * API key name
+         */
+        std::string name;
+
+        /**
+         * Key type (always "API_KEY")
+         */
+        std::string type{"API_KEY"};
+
+        /**
+         * Raw key value
+         */
+        std::string value;
+
+      private:
+
+        friend CreateUsagePlanKeyResponse tag_invoke(boost::json::value_to_tag<CreateUsagePlanKeyResponse>, boost::json::value const &v) {
+            CreateUsagePlanKeyResponse r;
+            r.id = Core::Json::GetStringValue(v, "id");
+            r.name = Core::Json::GetStringValue(v, "name");
+            r.type = Core::Json::GetStringValue(v, "type");
+            r.value = Core::Json::GetStringValue(v, "value");
+            return r;
+        }
+
+        friend void tag_invoke(boost::json::value_from_tag, boost::json::value &jv, CreateUsagePlanKeyResponse const &obj) {
+            jv = {
+                    {"Region", obj.region},
+                    {"User", obj.user},
+                    {"RequestId", obj.requestId},
+                    {"id", obj.id},
+                    {"name", obj.name},
+                    {"type", obj.type},
+                    {"value", obj.value},
+            };
+        }
+    };
+
+}// namespace Awsmock::Dto::ApiGateway

--- a/dto/include/awsmock/dto/apigateway/CreateUsagePlanRequest.h
+++ b/dto/include/awsmock/dto/apigateway/CreateUsagePlanRequest.h
@@ -1,0 +1,102 @@
+//
+// Created by vogje01 on 07/08/2026
+//
+
+#pragma once
+
+// C++ standard includes
+#include <map>
+#include <string>
+
+// AwsMock includes
+#include <awsmock/dto/common/BaseCounter.h>
+
+namespace Awsmock::Dto::ApiGateway {
+
+    /**
+     * @brief Create usage plan quota
+     */
+    struct CreateUsagePlanQuota {
+        long limit{};
+        long offset{};
+        std::string period;
+    };
+
+    /**
+     * @brief Create usage plan throttle
+     */
+    struct CreateUsagePlanThrottle {
+        long burstLimit{};
+        double rateLimit{};
+    };
+
+    /**
+     * @brief Create API gateway usage plan request
+     *
+     * @author jens.vogt\@opitz-consulting.com
+     */
+    struct CreateUsagePlanRequest final : Common::BaseCounter<CreateUsagePlanRequest> {
+
+        /**
+         * Usage plan name
+         */
+        std::string name;
+
+        /**
+         * Description
+         */
+        std::string description;
+
+        /**
+         * Quota settings
+         */
+        CreateUsagePlanQuota quota;
+
+        /**
+         * Throttle settings
+         */
+        CreateUsagePlanThrottle throttle;
+
+        /**
+         * Tags
+         */
+        std::map<std::string, std::string> tags;
+
+      private:
+
+        friend CreateUsagePlanRequest tag_invoke(boost::json::value_to_tag<CreateUsagePlanRequest>, boost::json::value const &v) {
+            CreateUsagePlanRequest r;
+            r.name = Core::Json::GetStringValue(v, "name");
+            r.description = Core::Json::GetStringValue(v, "description");
+            if (Core::Json::AttributeExists(v, "quota")) {
+                const auto &q = v.at("quota");
+                r.quota.limit = Core::Json::GetLongValue(q, "limit");
+                r.quota.offset = Core::Json::GetLongValue(q, "offset");
+                r.quota.period = Core::Json::GetStringValue(q, "period");
+            }
+            if (Core::Json::AttributeExists(v, "throttle")) {
+                const auto &t = v.at("throttle");
+                r.throttle.burstLimit = Core::Json::GetLongValue(t, "burstLimit");
+                r.throttle.rateLimit = Core::Json::GetDoubleValue(t, "rateLimit");
+            }
+            if (Core::Json::AttributeExists(v, "tags")) {
+                r.tags = boost::json::value_to<std::map<std::string, std::string>>(v.at("tags"));
+            }
+            return r;
+        }
+
+        friend void tag_invoke(boost::json::value_from_tag, boost::json::value &jv, CreateUsagePlanRequest const &obj) {
+            jv = {
+                    {"Region", obj.region},
+                    {"User", obj.user},
+                    {"RequestId", obj.requestId},
+                    {"name", obj.name},
+                    {"description", obj.description},
+                    {"quota", {{"limit", obj.quota.limit}, {"offset", obj.quota.offset}, {"period", obj.quota.period}}},
+                    {"throttle", {{"burstLimit", obj.throttle.burstLimit}, {"rateLimit", obj.throttle.rateLimit}}},
+                    {"tags", boost::json::value_from(obj.tags)},
+            };
+        }
+    };
+
+}// namespace Awsmock::Dto::ApiGateway

--- a/dto/include/awsmock/dto/apigateway/CreateUsagePlanResponse.h
+++ b/dto/include/awsmock/dto/apigateway/CreateUsagePlanResponse.h
@@ -1,0 +1,107 @@
+//
+// Created by vogje01 on 07/08/2026
+//
+
+#pragma once
+
+// C++ standard includes
+#include <map>
+#include <string>
+
+// AwsMock includes
+#include <awsmock/dto/common/BaseCounter.h>
+
+namespace Awsmock::Dto::ApiGateway {
+
+    /**
+     * @brief Create API gateway usage plan response
+     *
+     * @author jens.vogt\@opitz-consulting.com
+     */
+    struct CreateUsagePlanResponse final : Common::BaseCounter<CreateUsagePlanResponse> {
+
+        /**
+         * Usage plan ID
+         */
+        std::string id;
+
+        /**
+         * Usage plan name
+         */
+        std::string name;
+
+        /**
+         * Description
+         */
+        std::string description;
+
+        /**
+         * Quota limit
+         */
+        long quotaLimit{};
+
+        /**
+         * Quota offset
+         */
+        long quotaOffset{};
+
+        /**
+         * Quota period
+         */
+        std::string quotaPeriod;
+
+        /**
+         * Throttle burst limit
+         */
+        long throttleBurstLimit{};
+
+        /**
+         * Throttle rate limit
+         */
+        double throttleRateLimit{};
+
+        /**
+         * Tags
+         */
+        std::map<std::string, std::string> tags;
+
+      private:
+
+        friend CreateUsagePlanResponse tag_invoke(boost::json::value_to_tag<CreateUsagePlanResponse>, boost::json::value const &v) {
+            CreateUsagePlanResponse r;
+            r.id = Core::Json::GetStringValue(v, "id");
+            r.name = Core::Json::GetStringValue(v, "name");
+            r.description = Core::Json::GetStringValue(v, "description");
+            if (Core::Json::AttributeExists(v, "quota")) {
+                const auto &q = v.at("quota");
+                r.quotaLimit = Core::Json::GetLongValue(q, "limit");
+                r.quotaOffset = Core::Json::GetLongValue(q, "offset");
+                r.quotaPeriod = Core::Json::GetStringValue(q, "period");
+            }
+            if (Core::Json::AttributeExists(v, "throttle")) {
+                const auto &t = v.at("throttle");
+                r.throttleBurstLimit = Core::Json::GetLongValue(t, "burstLimit");
+                r.throttleRateLimit = Core::Json::GetDoubleValue(t, "rateLimit");
+            }
+            if (Core::Json::AttributeExists(v, "tags")) {
+                r.tags = boost::json::value_to<std::map<std::string, std::string>>(v.at("tags"));
+            }
+            return r;
+        }
+
+        friend void tag_invoke(boost::json::value_from_tag, boost::json::value &jv, CreateUsagePlanResponse const &obj) {
+            jv = {
+                    {"Region", obj.region},
+                    {"User", obj.user},
+                    {"RequestId", obj.requestId},
+                    {"id", obj.id},
+                    {"name", obj.name},
+                    {"description", obj.description},
+                    {"quota", {{"limit", obj.quotaLimit}, {"offset", obj.quotaOffset}, {"period", obj.quotaPeriod}}},
+                    {"throttle", {{"burstLimit", obj.throttleBurstLimit}, {"rateLimit", obj.throttleRateLimit}}},
+                    {"tags", boost::json::value_from(obj.tags)},
+            };
+        }
+    };
+
+}// namespace Awsmock::Dto::ApiGateway

--- a/dto/include/awsmock/dto/apigateway/DeleteUsagePlanRequest.h
+++ b/dto/include/awsmock/dto/apigateway/DeleteUsagePlanRequest.h
@@ -1,0 +1,45 @@
+//
+// Created by vogje01 on 01/09/2025
+//
+
+#pragma once
+
+// C++ standard includes
+#include <string>
+
+// AwsMock includes
+#include <awsmock/dto/common/BaseCounter.h>
+
+namespace Awsmock::Dto::ApiGateway {
+
+    /**
+     * @brief Delete usage plan request
+     *
+     * @author jens.vogt\@opitz-consulting.com
+     */
+    struct DeleteUsagePlanRequest final : Common::BaseCounter<DeleteUsagePlanRequest> {
+
+        /**
+         * Usage plan ID
+         */
+        std::string usagePlanId;
+
+      private:
+
+        friend DeleteUsagePlanRequest tag_invoke(boost::json::value_to_tag<DeleteUsagePlanRequest>, boost::json::value const &v) {
+            DeleteUsagePlanRequest r;
+            r.usagePlanId = Core::Json::GetStringValue(v, "usagePlanId");
+            return r;
+        }
+
+        friend void tag_invoke(boost::json::value_from_tag, boost::json::value &jv, DeleteUsagePlanRequest const &obj) {
+            jv = {
+                    {"region", obj.region},
+                    {"user", obj.user},
+                    {"requestId", obj.requestId},
+                    {"usagePlanId", obj.usagePlanId},
+            };
+        }
+    };
+
+}// namespace Awsmock::Dto::ApiGateway

--- a/dto/include/awsmock/dto/common/ApiGatewayClientCommand.h
+++ b/dto/include/awsmock/dto/common/ApiGatewayClientCommand.h
@@ -42,6 +42,7 @@ namespace Awsmock::Dto::Common {
         GET_RESOURCE,
         CREATE_USAGE_PLAN,
         CREATE_USAGE_PLAN_KEY,
+        DELETE_USAGE_PLAN,
         // AwsMock internal
         LIST_API_KEY_COUNTERS,
         GET_API_KEY_COUNTER,
@@ -71,6 +72,7 @@ namespace Awsmock::Dto::Common {
             {ApiGatewayCommandType::GET_RESOURCE, "get-resource"},
             {ApiGatewayCommandType::CREATE_USAGE_PLAN, "create-usage-plan"},
             {ApiGatewayCommandType::CREATE_USAGE_PLAN_KEY, "create-usage-plan-key"},
+            {ApiGatewayCommandType::DELETE_USAGE_PLAN, "delete-usage-plan"},
             // AwsMock internal commands
             {ApiGatewayCommandType::LIST_API_KEY_COUNTERS, "list-api-key-counters"},
             {ApiGatewayCommandType::GET_API_KEY_COUNTER, "get-api-key-counter"},

--- a/dto/include/awsmock/dto/common/ApiGatewayClientCommand.h
+++ b/dto/include/awsmock/dto/common/ApiGatewayClientCommand.h
@@ -40,6 +40,8 @@ namespace Awsmock::Dto::Common {
         DELETE_INTEGRATION,
         GET_RESOURCES,
         GET_RESOURCE,
+        CREATE_USAGE_PLAN,
+        CREATE_USAGE_PLAN_KEY,
         // AwsMock internal
         LIST_API_KEY_COUNTERS,
         GET_API_KEY_COUNTER,
@@ -67,6 +69,8 @@ namespace Awsmock::Dto::Common {
             {ApiGatewayCommandType::DELETE_INTEGRATION, "delete-integration"},
             {ApiGatewayCommandType::GET_RESOURCES, "get-resources"},
             {ApiGatewayCommandType::GET_RESOURCE, "get-resource"},
+            {ApiGatewayCommandType::CREATE_USAGE_PLAN, "create-usage-plan"},
+            {ApiGatewayCommandType::CREATE_USAGE_PLAN_KEY, "create-usage-plan-key"},
             // AwsMock internal commands
             {ApiGatewayCommandType::LIST_API_KEY_COUNTERS, "list-api-key-counters"},
             {ApiGatewayCommandType::GET_API_KEY_COUNTER, "get-api-key-counter"},

--- a/srv/include/awsmock/service/apigateway/ApiGatewayService.h
+++ b/srv/include/awsmock/service/apigateway/ApiGatewayService.h
@@ -25,6 +25,7 @@
 #include <awsmock/dto/apigateway/CreateRestApiRequest.h>
 #include <awsmock/dto/apigateway/CreateRestApiResponse.h>
 #include <awsmock/dto/apigateway/DeleteApiKeyRequest.h>
+#include <awsmock/dto/apigateway/DeleteUsagePlanRequest.h>
 #include <awsmock/dto/apigateway/DeleteResourceRequest.h>
 #include <awsmock/dto/apigateway/DeleteRestApiRequest.h>
 #include <awsmock/dto/apigateway/GetApiKeysRequest.h>
@@ -118,6 +119,13 @@ namespace Awsmock::Service {
          * @param request delete API key request
          */
         void deleteApiKey(const Dto::ApiGateway::DeleteApiKeyRequest &request) const;
+
+        /**
+         * @brief Deletes a usage plan
+         *
+         * @param request delete usage plan request
+         */
+        void deleteUsagePlan(const Dto::ApiGateway::DeleteUsagePlanRequest &request) const;
 
         /**
          * @brief Creates a new REST API

--- a/srv/include/awsmock/service/apigateway/ApiGatewayService.h
+++ b/srv/include/awsmock/service/apigateway/ApiGatewayService.h
@@ -16,6 +16,10 @@
 #include <awsmock/core/monitoring/MonitoringTimer.h>
 #include <awsmock/dto/apigateway/CreateApiKeyRequest.h>
 #include <awsmock/dto/apigateway/CreateApiKeyResponse.h>
+#include <awsmock/dto/apigateway/CreateUsagePlanKeyRequest.h>
+#include <awsmock/dto/apigateway/CreateUsagePlanKeyResponse.h>
+#include <awsmock/dto/apigateway/CreateUsagePlanRequest.h>
+#include <awsmock/dto/apigateway/CreateUsagePlanResponse.h>
 #include <awsmock/dto/apigateway/CreateResourceRequest.h>
 #include <awsmock/dto/apigateway/CreateResourceResponse.h>
 #include <awsmock/dto/apigateway/CreateRestApiRequest.h>
@@ -89,6 +93,24 @@ namespace Awsmock::Service {
          */
         [[nodiscard]]
         Dto::ApiGateway::GetApiKeysResponse getApiKeys(const Dto::ApiGateway::GetApiKeysRequest &request) const;
+
+        /**
+         * @brief Creates a usage plan
+         *
+         * @param request create usage plan request
+         * @return create usage plan response
+         */
+        [[nodiscard]]
+        Dto::ApiGateway::CreateUsagePlanResponse createUsagePlan(const Dto::ApiGateway::CreateUsagePlanRequest &request) const;
+
+        /**
+         * @brief Associates an API key with a usage plan
+         *
+         * @param request create usage plan key request
+         * @return create usage plan key response
+         */
+        [[nodiscard]]
+        Dto::ApiGateway::CreateUsagePlanKeyResponse createUsagePlanKey(const Dto::ApiGateway::CreateUsagePlanKeyRequest &request) const;
 
         /**
          * @brief Deletes an API gateway key

--- a/srv/src/apigateway/ApiGatewayHandler.cpp
+++ b/srv/src/apigateway/ApiGatewayHandler.cpp
@@ -167,7 +167,7 @@ namespace Awsmock::Service {
                 http::response<http::dynamic_body> res;
                 http::read(stream, buf, res);
                 beast::error_code ec;
-                stream.socket().shutdown(ip::tcp::socket::shutdown_both, ec);
+                std::ignore = stream.socket().shutdown(ip::tcp::socket::shutdown_both, ec);
                 return res;
 
             } catch (const std::exception &exc) {
@@ -354,6 +354,23 @@ namespace Awsmock::Service {
                     const Dto::ApiGateway::CreateResourceResponse serviceResponse = _apiGatewayService.createResource(serviceRequest);
                     log_info << "REST resource created, pathPart: " << serviceRequest.pathPart;
                     return SendResponse(request, http::status::ok, serviceResponse.ToJson());
+                }
+
+                case Dto::Common::ApiGatewayCommandType::CREATE_USAGE_PLAN: {
+
+                    Dto::ApiGateway::CreateUsagePlanRequest serviceRequest = Dto::ApiGateway::CreateUsagePlanRequest::FromJson(clientCommand);
+                    const Dto::ApiGateway::CreateUsagePlanResponse serviceResponse = _apiGatewayService.createUsagePlan(serviceRequest);
+                    log_info << "Usage plan created, id: " << serviceResponse.id;
+                    return SendResponse(request, http::status::created, serviceResponse.ToJson());
+                }
+
+                case Dto::Common::ApiGatewayCommandType::CREATE_USAGE_PLAN_KEY: {
+
+                    Dto::ApiGateway::CreateUsagePlanKeyRequest serviceRequest = Dto::ApiGateway::CreateUsagePlanKeyRequest::FromJson(clientCommand);
+                    serviceRequest.usagePlanId = Core::HttpUtils::GetPathParameter(request.target(), 1);
+                    const Dto::ApiGateway::CreateUsagePlanKeyResponse serviceResponse = _apiGatewayService.createUsagePlanKey(serviceRequest);
+                    log_info << "Usage plan key created, usagePlanId: " << serviceRequest.usagePlanId << " keyId: " << serviceRequest.keyId;
+                    return SendResponse(request, http::status::created, serviceResponse.ToJson());
                 }
 
                 default:

--- a/srv/src/apigateway/ApiGatewayHandler.cpp
+++ b/srv/src/apigateway/ApiGatewayHandler.cpp
@@ -5,6 +5,7 @@
 #include <awsmock/service/apigateway/ApiGatewayHandler.h>
 
 #include "awsmock/dto/apigateway/DeleteResourceRequest.h"
+#include "awsmock/dto/apigateway/DeleteUsagePlanRequest.h"
 #include "awsmock/dto/apigateway/GetResourceRequest.h"
 #include <awsmock/core/JsonUtils.h>
 
@@ -487,6 +488,15 @@ namespace Awsmock::Service {
                     _apiGatewayService.deleteIntegration(restApiId, resourceId, httpMethod);
                     log_info << "Integration deleted, restApiId: " << restApiId << ", resourceId: " << resourceId << ", httpMethod: " << httpMethod;
                     return SendResponse(request, http::status::no_content);
+                }
+
+                case Dto::Common::ApiGatewayCommandType::DELETE_USAGE_PLAN: {
+
+                    Dto::ApiGateway::DeleteUsagePlanRequest serviceRequest;
+                    serviceRequest.usagePlanId = Core::HttpUtils::GetPathParameter(request.target(), 1);
+                    _apiGatewayService.deleteUsagePlan(serviceRequest);
+                    log_info << "Usage plan deleted, id: " << serviceRequest.usagePlanId;
+                    return SendResponse(request, http::status::accepted);
                 }
 
                 default:

--- a/srv/src/apigateway/ApiGatewayService.cpp
+++ b/srv/src/apigateway/ApiGatewayService.cpp
@@ -159,6 +159,24 @@ namespace Awsmock::Service {
         }
     }
 
+    void ApiGatewayService::deleteUsagePlan(const Dto::ApiGateway::DeleteUsagePlanRequest &request) const {
+        Monitoring::MonitoringTimer measure(API_GATEWAY_SERVICE_TIMER, API_GATEWAY_SERVICE_COUNTER, "action", "delete_usage_plan");
+        log_debug << "Delete usage plan request, region: " << request.region << " usagePlanId: " << request.usagePlanId;
+
+        if (!_apiGatewayDatabase->usagePlanExists(request.usagePlanId)) {
+            log_error << "Usage plan does not exist, region: " << request.region << " usagePlanId: " << request.usagePlanId;
+            throw Core::ServiceException("Usage plan does not exist, region: " + request.region + " usagePlanId: " + request.usagePlanId);
+        }
+
+        try {
+            _apiGatewayDatabase->deleteUsagePlan(request.usagePlanId);
+            log_trace << "Usage plan deleted, id: " << request.usagePlanId;
+        } catch (bsoncxx::exception &exc) {
+            log_error << exc.what();
+            throw Core::ServiceException(exc.what());
+        }
+    }
+
     Dto::ApiGateway::CreateRestApiResponse ApiGatewayService::createRestApi(const Dto::ApiGateway::CreateRestApiRequest &request) const {
         Monitoring::MonitoringTimer measure(API_GATEWAY_SERVICE_TIMER, API_GATEWAY_SERVICE_COUNTER, "action", "create_rest_api");
         log_debug << "Create REST API request, region:  " << request.region << ", name: " << request.name;

--- a/srv/src/apigateway/ApiGatewayService.cpp
+++ b/srv/src/apigateway/ApiGatewayService.cpp
@@ -45,6 +45,73 @@ namespace Awsmock::Service {
         }
     }
 
+    Dto::ApiGateway::CreateUsagePlanResponse ApiGatewayService::createUsagePlan(const Dto::ApiGateway::CreateUsagePlanRequest &request) const {
+        Monitoring::MonitoringTimer measure(API_GATEWAY_SERVICE_TIMER, API_GATEWAY_SERVICE_COUNTER, "action", "create_usage_plan");
+        log_debug << "Create usage plan, name: " << request.name;
+
+        try {
+            Database::Entity::ApiGateway::UsagePlan plan;
+            plan.region = request.region;
+            plan.id = Core::AwsUtils::CreateApiKeyId();
+            plan.name = request.name;
+            plan.description = request.description;
+            plan.quota.limit = request.quota.limit;
+            plan.quota.offset = request.quota.offset;
+            plan.quota.period = request.quota.period;
+            plan.throttle.burstLimit = request.throttle.burstLimit;
+            plan.throttle.rateLimit = request.throttle.rateLimit;
+            plan.tags = request.tags;
+            plan = _apiGatewayDatabase->createUsagePlan(plan);
+
+            Dto::ApiGateway::CreateUsagePlanResponse response;
+            response.copyMetadata(request);
+            response.id = plan.id;
+            response.name = plan.name;
+            response.description = plan.description;
+            response.quotaLimit = plan.quota.limit;
+            response.quotaOffset = plan.quota.offset;
+            response.quotaPeriod = plan.quota.period;
+            response.throttleBurstLimit = plan.throttle.burstLimit;
+            response.throttleRateLimit = plan.throttle.rateLimit;
+            response.tags = plan.tags;
+            log_info << "Usage plan created, id: " << plan.id;
+            return response;
+
+        } catch (bsoncxx::exception &exc) {
+            log_error << exc.what();
+            throw Core::ServiceException(exc.what());
+        }
+    }
+
+    Dto::ApiGateway::CreateUsagePlanKeyResponse ApiGatewayService::createUsagePlanKey(const Dto::ApiGateway::CreateUsagePlanKeyRequest &request) const {
+        Monitoring::MonitoringTimer measure(API_GATEWAY_SERVICE_TIMER, API_GATEWAY_SERVICE_COUNTER, "action", "create_usage_plan_key");
+        log_debug << "Create usage plan key, usagePlanId: " << request.usagePlanId << " keyId: " << request.keyId;
+
+        if (!_apiGatewayDatabase->apiKeyExists(request.keyId)) {
+            log_error << "API key not found, keyId: " << request.keyId;
+            throw Core::NotFoundException("API key not found, keyId: " + request.keyId);
+        }
+
+        try {
+            Database::Entity::ApiGateway::ApiKey key = _apiGatewayDatabase->getApiKeyById(request.keyId);
+            key.usagePlanId = request.usagePlanId;
+            key = _apiGatewayDatabase->updateApiKey(key);
+
+            Dto::ApiGateway::CreateUsagePlanKeyResponse response;
+            response.copyMetadata(request);
+            response.id = key.id;
+            response.name = key.name;
+            response.type = request.keyType;
+            response.value = key.keyValue;
+            log_info << "Usage plan key created, usagePlanId: " << request.usagePlanId << " keyId: " << key.id;
+            return response;
+
+        } catch (bsoncxx::exception &exc) {
+            log_error << exc.what();
+            throw Core::ServiceException(exc.what());
+        }
+    }
+
     Dto::ApiGateway::GetApiKeysResponse ApiGatewayService::getApiKeys(const Dto::ApiGateway::GetApiKeysRequest &request) const {
         Monitoring::MonitoringTimer measure(API_GATEWAY_SERVICE_TIMER, API_GATEWAY_SERVICE_COUNTER, "action", "get_api_keys");
         log_debug << "Get API keys request, region:  " << request.region;

--- a/srv/src/apigateway/ApiGatewayService.cpp
+++ b/srv/src/apigateway/ApiGatewayService.cpp
@@ -603,7 +603,7 @@ namespace Awsmock::Service {
         method.integrationType.clear();
         method.integrationUri.clear();
         method.integrationHttpMethod.clear();
-        _apiGatewayDatabase->upsertRestApi(restApi);
+        std::ignore = _apiGatewayDatabase->upsertRestApi(restApi);
         log_debug << "Integration deleted, restApiId: " << restApiId << ", resourceId: " << resourceId << ", httpMethod: " << httpMethod;
     }
 

--- a/srv/tst/ApiGatewayServiceTest.cpp
+++ b/srv/tst/ApiGatewayServiceTest.cpp
@@ -21,6 +21,8 @@ namespace {
 #define TEST_INTEGRATION_TYPE "AWS_PROXY"
 #define TEST_INTEGRATION_URI "arn:aws:apigateway:eu-central-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-central-1:000000000000:function:test-fn/invocations"
 #define TEST_INTEGRATION_HTTP_METHOD "POST"
+#define TEST_API_KEY_NAME "test-api-key"
+#define TEST_USAGE_PLAN_NAME "test-usage-plan"
 
 namespace Awsmock::Database {
 
@@ -29,6 +31,26 @@ namespace Awsmock::Database {
         request.region = TEST_REGION;
         request.name = TEST_REST_API_NAME;
         return svc.createRestApi(request);
+    }
+
+    Dto::ApiGateway::CreateApiKeyResponse CreateDefaultApiKey(const Service::ApiGatewayService &svc) {
+        Dto::ApiGateway::CreateApiKeyRequest request;
+        request.region = TEST_REGION;
+        request.name = TEST_API_KEY_NAME;
+        request.enabled = true;
+        return svc.createApiKey(request);
+    }
+
+    Dto::ApiGateway::CreateUsagePlanResponse CreateDefaultUsagePlan(const Service::ApiGatewayService &svc) {
+        Dto::ApiGateway::CreateUsagePlanRequest request;
+        request.region = TEST_REGION;
+        request.name = TEST_USAGE_PLAN_NAME;
+        request.description = "test usage plan";
+        request.quota.limit = 1000;
+        request.quota.period = "DAY";
+        request.throttle.burstLimit = 50;
+        request.throttle.rateLimit = 10.0;
+        return svc.createUsagePlan(request);
     }
 
     Dto::ApiGateway::CreateResourceResponse CreateDefaultResource(const Service::ApiGatewayService &svc, const std::string &restApiId, const std::string &parentId) {
@@ -51,6 +73,7 @@ namespace Awsmock::Database {
                     Database::RepositoryFactory::instance().apigatewayRepository()->deleteRestApi(api.id);
                 }
                 Database::RepositoryFactory::instance().apigatewayRepository()->deleteAllKeys();
+                Database::RepositoryFactory::instance().apigatewayRepository()->deleteAllUsagePlans();
             } catch (const std::exception &exc) {
                 log_error << "ApiGateway fixture cleanup failed: " << exc.what();
             }
@@ -265,6 +288,62 @@ namespace Awsmock::Database {
         listRequest.region = TEST_REGION;
         const auto listResponse = svc.getRestApis(listRequest);
         BOOST_CHECK_EQUAL(0, listResponse.restApis.size());
+    }
+
+    BOOST_AUTO_TEST_CASE(CreateApiKeyTest) {
+
+        // arrange
+        Service::ApiGatewayService svc{_ioc};
+
+        // act
+        const auto response = CreateDefaultApiKey(svc);
+
+        // assert
+        BOOST_CHECK_EQUAL(false, response.id.empty());
+        BOOST_CHECK_EQUAL(TEST_API_KEY_NAME, response.name);
+        BOOST_CHECK_EQUAL(true, response.enabled);
+    }
+
+    BOOST_AUTO_TEST_CASE(CreateUsagePlanTest) {
+
+        // arrange
+        Service::ApiGatewayService svc{_ioc};
+
+        // act
+        const auto response = CreateDefaultUsagePlan(svc);
+
+        // assert
+        BOOST_CHECK_EQUAL(false, response.id.empty());
+        BOOST_CHECK_EQUAL(TEST_USAGE_PLAN_NAME, response.name);
+        BOOST_CHECK_EQUAL(1000, response.quotaLimit);
+        BOOST_CHECK_EQUAL("DAY", response.quotaPeriod);
+        BOOST_CHECK_EQUAL(50, response.throttleBurstLimit);
+        BOOST_CHECK_EQUAL(10.0, response.throttleRateLimit);
+    }
+
+    BOOST_AUTO_TEST_CASE(CreateUsagePlanKeyTest) {
+
+        // arrange
+        Service::ApiGatewayService svc{_ioc};
+        const auto key = CreateDefaultApiKey(svc);
+        BOOST_CHECK_EQUAL(false, key.id.empty());
+        const auto plan = CreateDefaultUsagePlan(svc);
+        BOOST_CHECK_EQUAL(false, plan.id.empty());
+
+        Dto::ApiGateway::CreateUsagePlanKeyRequest request;
+        request.region = TEST_REGION;
+        request.usagePlanId = plan.id;
+        request.keyId = key.id;
+        request.keyType = "API_KEY";
+
+        // act
+        const auto response = svc.createUsagePlanKey(request);
+
+        // assert
+        BOOST_CHECK_EQUAL(key.id, response.id);
+        BOOST_CHECK_EQUAL(TEST_API_KEY_NAME, response.name);
+        BOOST_CHECK_EQUAL("API_KEY", response.type);
+        BOOST_CHECK_EQUAL(false, response.value.empty());
     }
 
     BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- **864 transfer details page missing in frontend (#886)**
- **861 lambda invocation (#935)**
- **Merge pull request #974**
- **Merge pull request #981**
- **Merge pull request #1003**
- **861 lambda invocation (#1012)**
- **Merge pull request #1027**
- **Develop(999 using boost url) (#1093)**
- **1158 some issues with the docker containers (#1162)**
- **develop(1181-dynamodb-tablesitems-missing-in-ui): transfer counter serialization fix**
- **Merge pull request #1379**
- **Merge pull request #1497**
- **fix: bug in S3 lifecylce, default strorage class is 'STANDARD' (#1959)**
- **Merge pull request #2061**
- **Add s3 storage class (#2062)**
- **2084 application collection unique index (#2123)**
- **fix: SQS queue tagging (#2294)**
- **chore(main): release 1.18.42 (#2358)**
- **Merge pull request #2364**
- **2084 application collection unique index (#2369)**
- **2084 application collection unique index (#2371)**
- **2084 application collection unique index (#2372)**
- **Merge pull request #2373**
- **2084 application collection unique index (#2374)**
- **fix: add usage plans to api gateway service and repository implementations**
- **fix: add usage plans to api gateway service and repository implementations**
- **fix: add usage plans to api gateway service and repository implementations**
