### PR TITLE
fix: resolve vcpkg CI failures from mongo-c-driver overlay port

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.patch -text

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,7 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: ${{ env.VCPKG_ROOT }}
+          vcpkgJsonGlob: 'vcpkg.json'
 
       - name: Build (Backend)
         run: |
@@ -293,6 +294,7 @@ jobs:
         uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: ${{ env.VCPKG_ROOT }}
+          vcpkgJsonGlob: 'vcpkg.json'
 
       - name: Set g++-14 as default
         run: |


### PR DESCRIPTION
## Summary
- macOS and Linux release jobs fail at "Setup vcpkg" with `A Git commit id for vcpkg's baseline was not found nor in vcpkg.json nor in vcpkg-configuration.json`. The `mongo-c-driver` overlay port's own `vcpkg.json` makes `lukka/run-vcpkg`'s default `**/vcpkg.json` glob match two files, so it refuses to pick one. The Windows job already pins `vcpkgJsonGlob: 'vcpkg.json'`; this applies the same fix to macOS and Linux.
- The Windows job separately fails during `vcpkg install` with `Applying patch failed: error: corrupt patch` for `mongo-c-driver`, because the overlay port's `*.patch` files get CRLF-converted on checkout (`core.autocrlf=true`), corrupting them. Added `.gitattributes` marking `*.patch -text` so they're never line-ending-converted.

Confirmed against the currently in-progress/failing release run (release 1.18.101, commit `92107ac9`): macOS/Linux failed at "Setup vcpkg" with the baseline error, Windows failed later at "Build (Backend)" with the corrupt-patch error.

## Test plan
- [ ] Release workflow's macOS/Linux "Setup vcpkg" step succeeds (baseline resolved via vcpkg.json)
- [ ] Windows "Build (Backend)" step gets past `vcpkg install` for `mongo-c-driver` without a corrupt-patch error